### PR TITLE
Fix resolv.conf

### DIFF
--- a/build.go
+++ b/build.go
@@ -93,6 +93,8 @@ func runBuild(args []string) (exit int) {
 		c := nspawn.Init(l.Hash, fmt.Sprintf("%s/%s", home, l.Path))
 		c.SetBinds(append(f.Binds, f.Snapshots...))
 
+		c.Build("RUN", "rm -f /etc/resolv.conf")
+
 		if err := c.Build(cmd.Verb, cmd.Payload); err != nil {
 			fmt.Fprintln(os.Stderr, fmt.Sprintf("Buildstep failed: %v.", err))
 			if err = l.Remove(); err != nil {
@@ -101,8 +103,11 @@ func runBuild(args []string) (exit int) {
 			return 1
 		}
 
+		c.Build("RUN", "ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf")
+
 		parentPath = l.Path
 	}
+
 	if err = fs.Snapshot(parentPath, newImagePath, true); err != nil {
 		fmt.Fprintln(os.Stderr, "Couldn't create filesystem for new image.", err)
 		return 1

--- a/networkd/networkd.go
+++ b/networkd/networkd.go
@@ -39,8 +39,8 @@ Virtualization=container
 Name=host0
 
 [Network]
-DHCP=both
-IPv4LL=yes
+DHCP=v4
+IPv4LL=no
 
 [Route]
 Gateway={{.Destination}}.1

--- a/nspawn/container.go
+++ b/nspawn/container.go
@@ -20,14 +20,10 @@ Environment="BIND={{.Bind}}"
 	nspawnMachineIdTemplate string = `{{.MachineId}}
 `
 	buildstepTemplate string = `#!/bin/sh
-mkdir -p /run/systemd/resolve
-echo 'nameserver 8.8.8.8' > /run/systemd/resolve/resolv.conf
 
 {{.Payload}}
 
 rc=$?
-
-rm -f /run/systemd/resolve/resolv.conf
 
 exit $rc
 `

--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -90,6 +90,9 @@ func CreateImage(name, path string) error {
 	c := Init(name, fmt.Sprintf("%s/%s", path, name))
 
 	c.Build("ENABLE", "systemd-networkd systemd-resolved")
+	c.Build("RUN", "mkdir -p /etc/systemd/resolved.conf.d/")
+	c.Build("RUN", "echo '[Resolve]' > /etc/systemd/resolved.conf.d/conair.conf")
+	c.Build("RUN", "echo 'DNS=8.8.8.8 8.8.4.4' >> /etc/systemd/resolved.conf.d/conair.conf")
 	c.Build("RUN", "rm -f /etc/resolv.conf")
 	c.Build("RUN", "ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf")
 

--- a/rmi.go
+++ b/rmi.go
@@ -43,10 +43,9 @@ func runRmi(args []string) (exit int) {
 			return 1
 		}
 
-		layer, err = fs.GetLayerByUuid(uuid)
+		layer, _ = fs.GetLayerByUuid(uuid)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Couldn't find parent layer.", err)
-			return 1
+			layer = imagePath
 		}
 
 		if err := fs.Remove(imagePath); err != nil {


### PR DESCRIPTION
Use `/etc/systemd/resolved.conf.d/`to generate a correct `/run/systemd/resolve/resolv.conf`. For the build step I still link the `/etc/resolv.conf` from the host since containers are not booted in the build step and systemd-resolved is not running.