### PR TITLE
Add all capabilities to nspawn containers

### DIFF
--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -18,7 +18,7 @@ Documentation=man:systemd-nspawn(1)
 [Service]
 ExecStartPre=/usr/bin/sed -i "s/REPLACE_ME/${MACHINE_ID}/" {{.Directory}}/%i/etc/machine-id
 ExecStartPre=/usr/bin/chmod -w {{.Directory}}/%i/etc/machine-id
-ExecStart=/usr/bin/systemd-nspawn --machine %i --uuid=${MACHINE_ID} --quiet --private-network --network-veth --network-bridge={{.Bridge}} --keep-unit --boot --link-journal=guest --directory={{.Directory}}/%i $BIND
+ExecStart=/usr/bin/systemd-nspawn --machine %i --uuid=${MACHINE_ID} --capability=all --quiet --private-network --network-veth --network-bridge={{.Bridge}} --keep-unit --boot --link-journal=guest --directory={{.Directory}}/%i $BIND
 KillMode=mixed
 Type=notify
 


### PR DESCRIPTION
Conair is not for production. To let users do what ever they like in a conair container all capabilities will be allowed by default.

This lets you start a privileged docker container inside a conair container.

eg. you can run a weave network for docker containers inside conair containers.