### PR TITLE
Add /bin to env-path on FetchImage

### DIFF
--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -135,7 +135,7 @@ func FetchImage(image, newImage, url, path string) error {
 		"LANG=C",
 		"HOME=/root",
 		"PWD=/root",
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/core_perl",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/bin/core_perl",
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
At least on Ubuntu this is needed to access bzip2:

$ which bzip2
/bin/bzip2